### PR TITLE
Conditional

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "use-shared-resize-observer",
   "version": "0.2.0",
   "main": "./dist/commonjs/use-shared-resize-observer.js",
+  "repository": "hipstersmoothie/use-shared-resize-observer",
   "scripts": {
     "build": "tshy",
     "dev": "ladle serve",
@@ -9,7 +10,7 @@
     "release": "pnpm build && auto shipit"
   },
   "keywords": [],
-  "author": "",
+  "author": "Andrew Lisowski <lisowski54@gmail.com>",
   "license": "ISC",
   "description": "",
   "devDependencies": {

--- a/src/stories/use-size.stories.tsx
+++ b/src/stories/use-size.stories.tsx
@@ -79,3 +79,49 @@ export const ResizeObserver = () => {
     />
   );
 };
+
+export const ConditonalElement = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [variant, setVariant] = useState<"blue" | "red" | "green">("green");
+  const [toggle, setToggle] = useState(false);
+
+  useSharedResizeObserver({
+    ref,
+    onUpdate: (entry) => {
+      if (entry.contentRect.width > 400) {
+        setVariant("blue");
+      } else if (entry.contentRect.width < 100) {
+        setVariant("red");
+      } else {
+        setVariant("green");
+      }
+    },
+  });
+
+  const content = (
+    <div
+      ref={ref}
+      style={{
+        width: "150px",
+        height: "150px",
+        resize: "both",
+        overflow: "auto",
+        backgroundColor: variant,
+      }}
+    />
+  );
+
+  return (
+    <>
+      <button type="button" onClick={() => setToggle(!toggle)}>
+        Toggle
+      </button>
+
+      {toggle ? (
+        <div style={{ border: "1px solid red", padding: 8 }}>{content}</div>
+      ) : (
+        content
+      )}
+    </>
+  );
+};

--- a/src/use-shared-resize-observer.tsx
+++ b/src/use-shared-resize-observer.tsx
@@ -7,7 +7,6 @@ interface SharedResizeObserverContext<T extends HTMLElement | null> {
 }
 
 const elementMap = new Map<Element, ObserverEntry<HTMLElement | null>>();
-const instances = new Set<ObserverEntry<HTMLElement | null>>();
 let observer: ResizeObserver | undefined;
 let observerContext:
   | SharedResizeObserverContext<HTMLElement | null>
@@ -20,7 +19,7 @@ function createObserverContext() {
 
   observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
-      const instance = Array.from(instances).find(
+      const instance = Array.from(elementMap.values()).find(
         (i) => i.ref.current === entry.target
       );
 
@@ -52,7 +51,6 @@ function createObserverContext() {
       }
 
       observer?.observe(entry.ref.current);
-      instances.add(entry);
       elementMap.set(entry.ref.current, entry);
     },
     unobserve: (entry) => {
@@ -61,10 +59,9 @@ function createObserverContext() {
       }
 
       observer?.unobserve(entry.ref.current);
-      instances.delete(entry);
       elementMap.delete(entry.ref.current);
 
-      if (instances.size === 0) {
+      if (elementMap.size === 0) {
         observer?.disconnect();
         observer = undefined;
       }

--- a/src/use-shared-resize-observer.tsx
+++ b/src/use-shared-resize-observer.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from "react";
-import type { ObserverEntry, onUpdate } from "./types.js";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import type { ObserverEntry } from "./types.js";
 
 interface SharedResizeObserverContext<T extends HTMLElement | null> {
   observe: (entry: ObserverEntry<T>) => void;
   unobserve: (entry: ObserverEntry<T>) => void;
 }
 
-const cbMap = new Map<React.RefObject<HTMLElement | null>, onUpdate>();
+const elementMap = new Map<Element, ObserverEntry<HTMLElement | null>>();
+const instances = new Set<ObserverEntry<HTMLElement | null>>();
 let observer: ResizeObserver | undefined;
 let observerContext:
   | SharedResizeObserverContext<HTMLElement | null>
@@ -19,13 +20,27 @@ function createObserverContext() {
 
   observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
-      const [, cb] =
-        Array.from(cbMap.entries()).find(
-          ([ref]) => ref.current === entry.target
-        ) || [];
+      const instance = Array.from(instances).find(
+        (i) => i.ref.current === entry.target
+      );
 
-      if (cb) {
-        cb(entry);
+      if (instance) {
+        instance.onUpdate(entry);
+      }
+      // Else the instance is no longer in the DOM
+      else {
+        const instance = elementMap.get(entry.target);
+
+        // We found an entry for the detached element
+        if (instance?.ref.current) {
+          // Stop observing the detached element
+          observer?.unobserve(entry.target);
+          elementMap.delete(entry.target);
+
+          // Re-attach the instance with the new ref to the observer
+          observer?.observe(instance.ref.current);
+          elementMap.set(instance.ref.current, instance);
+        }
       }
     }
   });
@@ -37,7 +52,8 @@ function createObserverContext() {
       }
 
       observer?.observe(entry.ref.current);
-      cbMap.set(entry.ref, entry.onUpdate);
+      instances.add(entry);
+      elementMap.set(entry.ref.current, entry);
     },
     unobserve: (entry) => {
       if (!entry.ref.current) {
@@ -45,9 +61,10 @@ function createObserverContext() {
       }
 
       observer?.unobserve(entry.ref.current);
-      cbMap.delete(entry.ref);
+      instances.delete(entry);
+      elementMap.delete(entry.ref.current);
 
-      if (cbMap.size === 0) {
+      if (instances.size === 0) {
         observer?.disconnect();
         observer = undefined;
       }


### PR DESCRIPTION
When you conditional render a component in react the component gets recreated and `ref.current` is updated. The initial implementation did not account for this. So if you conditionally rendered an element the `observer` would be watching the first el rendered and not any of the new ones.

Instead of just mapping the el to the update function we map it to the whole `ObserverEntry`. This lets us recover from the conditional rendering by:

1. finding the instance the detached el is associated with
2. Updating the relevant state to watch the new el instead